### PR TITLE
fix: Messenger와 관련된 Entity에서 모든 연관 관계 삭제

### DIFF
--- a/src/main/java/org/shiftworksboot/entity/Chat.java
+++ b/src/main/java/org/shiftworksboot/entity/Chat.java
@@ -23,7 +23,4 @@ public class Chat {
 
     private String sender;
 
-    @ManyToOne
-    @JoinColumn(name = "room_id")
-    private ChatRoom chatRoom;
 }

--- a/src/main/java/org/shiftworksboot/entity/ChatRoomFile.java
+++ b/src/main/java/org/shiftworksboot/entity/ChatRoomFile.java
@@ -19,9 +19,4 @@ public class ChatRoomFile {
     private String file_name;
 
     private String file_src;
-
-    @ManyToOne
-    @JoinColumn(name = "room_id")
-    private ChatRoom chatRoom;
-
 }

--- a/src/main/java/org/shiftworksboot/entity/ChatRoomUser.java
+++ b/src/main/java/org/shiftworksboot/entity/ChatRoomUser.java
@@ -14,8 +14,6 @@ import javax.persistence.*;
 public class ChatRoomUser {
 
     @Id
-    @ManyToOne
-    @JoinColumn(name = "room_id")
-    private ChatRoom chatRoom;
+    private int chatRoomUser_id;
 
 }

--- a/src/main/java/org/shiftworksboot/entity/ChatRoomUser.java
+++ b/src/main/java/org/shiftworksboot/entity/ChatRoomUser.java
@@ -4,10 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Table(name = "chatroom_user")
@@ -18,6 +15,7 @@ public class ChatRoomUser {
 
     @Id
     @ManyToOne
+    @JoinColumn(name = "room_id")
     private ChatRoom chatRoom;
 
 }


### PR DESCRIPTION
fix: Messenger와 관련된 Entity에서 연관 관계 삭제

- 주식별 관계 매핑 에러로 인해 서버 실행이 불가함. 
- 연관 관계 삭제 (Chat.java, ChatRoomFile.java, ChatRoomUser.java) 
- 추후 연관 관계를 설정할 예정.